### PR TITLE
Fix worker cleanup race condition

### DIFF
--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -72,6 +72,13 @@ export function useTransactions() {
     return () => {
       worker.removeEventListener('message', handleMessage)
       worker.removeEventListener('error', handleError)
+
+      // Reject all pending promises before terminating to prevent memory leaks
+      pendingRef.current.forEach(({ reject }) => {
+        reject(new Error('Worker terminated during cleanup'))
+      })
+      pendingRef.current.clear()
+
       worker.terminate()
     }
   }, [])


### PR DESCRIPTION
Reject all pending promises before terminating the worker to prevent:
- Memory leaks from unreleased promise handlers
- Silent failures when worker is terminated mid-operation
- Unhandled promise rejections

When the component unmounts or the worker is cleaned up, all pending file parsing operations will now properly reject with a clear error message instead of hanging indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)